### PR TITLE
Fix llvm.rb --with-lldb on newer macos

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -209,7 +209,12 @@ class Llvm < Formula
       # which adds it to the superenv keychain search path.
       mkdir_p "#{ENV["HOME"]}/Library/Preferences"
       username = ENV["USER"]
-      system "security", "list-keychains", "-d", "user", "-s", "/Users/#{username}/Library/Keychains/login.keychain"
+      userdir  = `echo ~#{username}`.chomp
+      keychain = "#{userdir}/Library/Keychains/login.keychain-db"
+      if ! File.exist? keychain
+         keychain = "#{userdir}/Library/Keychains/login.keychain"
+      end 
+      system "security", "list-keychains", "-d", "user", "-s", keychain
     end
 
     if build.with? "compiler-rt"


### PR DESCRIPTION
* Fixes the assumption, that the HOME of a user is always in `/Users`
* keychain files have `keychain-db` extension in later macos versions

I use this in my derivative lldb formula. It should work in `llvm.rb` too. Haven't tested it though since llvm takes forever to build. The maintainer of `llvm.rb` might enjoy this though. (or not)
